### PR TITLE
add linking to ltinfow

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ AM_CFLAGS = -DSYSCONFIG=\"$(dfshowconfdir)\" -DDATADIR=\"$(dfshowdatadir)\" -D_X
 if DARWIN
 LDADD = -lncurses -lm -lconfig
 else
-LDADD = -lncursesw -lm -lconfig
+LDADD = -lncursesw -lm -lconfig -ltinfo
 endif
 
 bin_PROGRAMS = $(top_builddir)/bin/show $(top_builddir)/bin/sf


### PR DESCRIPTION
add explicit linking to ltinfow (from ncurses) to fix compilation issues on gentoo. will allow getting rid of the sed line in the ebuild.

While packaging dfshow for gentoo I came across an issue where unless Makefile.am was modified to link to ltinfow then the build would fail. I'm not sure if it's a difference in how ncurses is packaged or what but I tested it on ubuntu and adding this didn't affect anything so in theory it should be a safe addition.