### PR TITLE
Resolved duplicate definition error when using -fno-common

### DIFF
--- a/src/colors.c
+++ b/src/colors.c
@@ -44,7 +44,7 @@ colorPairs colors[256];
 
 char fgbgLabel[11];
 
-char errmessage[256];
+extern char errmessage[256];
 
 extern int colormode;
 extern int c;

--- a/src/common.c
+++ b/src/common.c
@@ -52,6 +52,8 @@ menuDef *settingsMenu;
 int settingsMenuSize = 0;
 wchar_t *settingsMenuLabel;
 
+char errmessage[256];
+
 extern int * pc;
 
 extern int resized;

--- a/src/showmenus.c
+++ b/src/showmenus.c
@@ -46,7 +46,6 @@ char ownerinput[256];
 char groupinput[256];
 char uids[24];
 char gids[24];
-char errmessage[256];
 char currentfilename[512];
 
 int s;
@@ -60,6 +59,8 @@ int abortinput = 0;
 
 struct utimbuf touchDate;
 time_t touchTime;
+
+extern char errmessage[256];
 
 extern results* ob;
 extern history* hs;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A duplicate definition for errmessage would cause gcc to fail when
building with the -fno-common flag.

## Motivation and Context
See issue #122

## How Has This Been Tested?
Tested locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.