### PR TITLE
correctly find and link to ncurses dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,10 +33,12 @@ endif
 bin_PROGRAMS = bin/show bin/sf
 bin_show_SOURCES = src/show.c src/showfunctions.c src/sffunctions.c src/showmenus.c src/sfmenus.c src/colors.c src/common.c src/menu.c src/input.c src/display.c src/settings.c src/i18n.c
 bin_show_LDADD = $(LDADD)
-bin_show_CFLAGS = $(EXTRA_CFLAGS) $(AM_CFLAGS) -DAPPLICATION_SHOW -DAPPLICATION_SF
+bin_show_CFLAGS = $(NCURSES_CFLAGS) $(EXTRA_CFLAGS) $(AM_CFLAGS) -DAPPLICATION_SHOW -DAPPLICATION_SF
+bin_show_LDFLAGS = $(NCURSES_LIBS) $(AM_LDFLAGS)
 bin_sf_SOURCES = src/sf.c src/sffunctions.c src/sfmenus.c src/colors.c src/common.c src/menu.c src/input.c src/display.c src/settings.c src/i18n.c
+bin_sf_LDFLAGS = $(NCURSES_LIBS) $(AM_LDFLAGS)
 bin_sf_LDADD = $(LDADD)
-bin_sf_CFLAGS = $(EXTRA_CFLAGS) $(AM_CFLAGS) -DAPPLICATION_SF
+bin_sf_CFLAGS = $(NCURSES_CFLAGS) $(EXTRA_CFLAGS) $(AM_CFLAGS) -DAPPLICATION_SF
 dfshowconf_DATA = conf/dfshow.conf
 dfshowdata_DATA = themes/*
 

--- a/configure.ac
+++ b/configure.ac
@@ -41,30 +41,14 @@ AC_CHECK_DECL([ACL_TYPE_EXTENDED],
     #include <sys/acl.h>])
 # Solaris and derivates ACLs
 AC_CHECK_LIB([sec], [acl_get])
-# Check for ncurses with wide character support
-AC_CHECK_LIB([ncursesw], [initscr], [],
-            [AC_MSG_ERROR([ncurses with wide character support not found.])])
 AC_CHECK_TYPES([aclent_t], [], [], [[#include <sys/acl.h>]])
 AC_CHECK_TYPES([ace_t], [], [], [[#include <sys/acl.h>]])
 AC_CHECK_FUNCS(acl_get facl_get acl_set facl_set)
 
-AC_CHECK_TOOL([UNAME], [uname], [false])
-case `$UNAME -s` in
-    Darwin*)
-        # macOS to use Homebrew version of ncurses which is v6
-        NCURSES_PREFIX=`brew --prefix ncurses`
-
-        CPPFLAGS="-I$NCURSES_PREFIX/include $CPPFLAGS"
-        LDFLAGS="-L$NCURSES_PREFIX/lib $LDFLAGS"
-        ;;
-
-    *)
-        ;;
-esac
+PKG_CHECK_MODULES([NCURSES], [ncursesw])
 
 AC_CHECK_MEMBERS([struct stat.st_author])
 AC_CHECK_HEADERS([stdio.h limits.h signal.h ctype.h wctype.h getopt.h sys/types.h sys/stat.h dirent.h fcntl.h pwd.h string.h stdlib.h unistd.h time.h sys/statvfs.h libgen.h errno.h wchar.h hurd.h math.h sys/sysmacros.h regex.h utime.h sys/xattr.h acl/libacl.h stdint.h])
-AC_CHECK_HEADERS(ncurses.h, , AC_MSG_ERROR(ncurses header (ncurses.h) not found. You may need to install an ncurses development package.))
 AC_CHECK_HEADERS(libconfig.h, , AC_MSG_ERROR(libconfig header (libconfig.h) not found. You may need to install a libconfig development package.))
 AC_CHECK_HEADERS(sys/acl.h, , AC_MSG_ERROR(libacl header (sys/acl.h) not found. You may need to install a libacl development package.))
 


### PR DESCRIPTION
Fixes wide character support, which previously provided no guarantee that the wide character version of ncurses.h was what was used to compile with.

Fixes #171

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
