### PR TITLE
Fix Makefile.am for gettext

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ AM_CFLAGS = -DSYSCONFIG=\"$(dfshowconfdir)\" -DDATADIR=\"$(dfshowdatadir)\" -D_X
 
 LDADD = -lm -lconfig $(LIBINTL)
 
+ACLOCAL_AMFLAGS = -I m4
+
 if DARWIN
 LDADD += -lncurses
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a flag to Makefile.am which should fix the build issue on Homebrew on macOS

## Motivation and Context
New version of gettext on macOS using homebrew fails to get past the bootstrap stage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
